### PR TITLE
use multithreading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
 name = "deunicode"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,12 +205,19 @@ dependencies = [
  "fake",
  "lazy_static",
  "rand",
+ "rayon",
  "regex",
  "serde",
  "serde_json",
  "url",
  "uuid",
 ]
+
+[[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "email_address"
@@ -378,6 +410,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,6 +203,7 @@ dependencies = [
  "clap",
  "email_address",
  "fake",
+ "jemallocator",
  "lazy_static",
  "rand",
  "rayon",
@@ -303,6 +304,26 @@ name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
+name = "jemalloc-sys"
+version = "0.5.4+5.3.0-patched"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "jemallocator"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0de374a9f8e63150e6f5e8a60cc14c668226d7a347d8aee1a45766e3c4dd3bc"
+dependencies = [
+ "jemalloc-sys",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ email_address = "0.2.4"
 fake = { version = "2.9.2", features = ["chrono"] }
 lazy_static = "1.4.0"
 rand = "0.8.1"
+rayon = "1.10.0"
 regex = "1.8.1"
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ chrono = "0.4.37"
 clap = { version = "4.5.4", features = ["derive"] }
 email_address = "0.2.4"
 fake = { version = "2.9.2", features = ["chrono"] }
+jemallocator = "0.5.4"
 lazy_static = "1.4.0"
 rand = "0.8.1"
 rayon = "1.10.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,10 @@ use std::io::Read;
 
 use clap::{Parser, Subcommand};
 use drivel::SchemaState;
+use jemallocator::Jemalloc;
+
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 #[derive(Subcommand, Debug)]
 enum Mode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-use std::io::Read;
-
 use clap::{Parser, Subcommand};
 use drivel::SchemaState;
 use jemallocator::Jemalloc;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::io::Read;
+
 use clap::{Parser, Subcommand};
 use drivel::SchemaState;
 
@@ -22,17 +24,18 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
-
     let input = std::io::read_to_string(std::io::stdin()).expect("Unable to read from stdin");
-
     let schema = if let Ok(json) = serde_json::from_str(&input) {
         drivel::infer_schema(json)
     } else {
         // unable to parse input as JSON; try JSON lines format as fallback
-        let values = input.lines().map(|line| {
-            serde_json::from_str(line)
-                .expect("Unable to parse input; format is neither JSON nor JSON lines")
-        });
+        let values = input
+            .lines()
+            .map(|line| {
+                serde_json::from_str(line)
+                    .expect("Unable to parse input; format is neither JSON nor JSON lines")
+            })
+            .collect();
         drivel::infer_schema_from_iter(values)
     };
 

--- a/src/produce.rs
+++ b/src/produce.rs
@@ -8,6 +8,7 @@ use fake::{
     Fake, Faker,
 };
 use rand::{random, thread_rng, Rng};
+use rayon::prelude::*;
 use serde_json::Number;
 
 use crate::{NumberType, SchemaState, StringType};
@@ -133,6 +134,7 @@ fn produce_inner(schema: &SchemaState, repeat_n: usize, current_depth: usize) ->
             };
 
             let data: Vec<_> = (0..n_elements)
+                .into_par_iter()
                 .map(|_| produce_inner(schema, repeat_n, current_depth + 1))
                 .collect();
             serde_json::Value::Array(data)


### PR DESCRIPTION
Closes #8 by introducing rayon to parallelise array schema inference as well as value production.

Benchmarking shows that jemalloc is required in order to see a perf benefit for operating on large (100+ MB) JSON files. Without changing allocator, there is a point at which multi-threading becomes _slower_ than single threaded on Linux due to the allocator working overtime.