### PR TITLE
Enable enum inference

### DIFF
--- a/src/infer.rs
+++ b/src/infer.rs
@@ -85,7 +85,7 @@ fn merge(initial: SchemaState, new: SchemaState) -> SchemaState {
                 SchemaState::String(first_type)
             } else {
                 SchemaState::String(StringType::Unknown {
-                    strings_seen: std::collections::HashSet::new(),
+                    strings_seen: vec![],
                     chars_seen: vec![],
                     min_length: None,
                     max_length: None,
@@ -427,7 +427,7 @@ mod tests {
         assert_eq!(
             schema,
             SchemaState::String(StringType::Unknown {
-                strings_seen: std::collections::HashSet::from_iter(["foo".to_owned()]),
+                strings_seen: vec!["foo".to_owned()],
                 chars_seen: vec!['f', 'o', 'o'],
                 min_length: Some(3),
                 max_length: Some(3)
@@ -601,7 +601,7 @@ mod tests {
                     (
                         "string".to_string(),
                         SchemaState::String(StringType::Unknown {
-                            strings_seen: std::collections::HashSet::from_iter(["foo".to_owned()]),
+                            strings_seen: vec!["foo".to_owned()],
                             chars_seen: vec!['f', 'o', 'o'],
                             min_length: Some(3),
                             max_length: Some(3)
@@ -625,9 +625,9 @@ mod tests {
                             min_length: 1,
                             max_length: 1,
                             schema: Box::new(SchemaState::String(StringType::Unknown {
-                                strings_seen: std::collections::HashSet::from_iter([
+                                strings_seen: vec![ 
                                     "baz".to_owned()
-                                ]),
+                                ],
                                 chars_seen: vec!['b', 'a', 'z'],
                                 min_length: Some(3),
                                 max_length: Some(3)
@@ -641,9 +641,9 @@ mod tests {
                             required: std::collections::HashMap::from_iter([(
                                 "string".to_owned(),
                                 SchemaState::String(StringType::Unknown {
-                                    strings_seen: std::collections::HashSet::from_iter([
+                                    strings_seen: vec![
                                         "foo".to_owned()
-                                    ]),
+                                    ],
                                     chars_seen: vec!['f', 'o', 'o'],
                                     min_length: Some(3),
                                     max_length: Some(3)
@@ -690,10 +690,10 @@ mod tests {
                 min_length: 2,
                 max_length: 2,
                 schema: Box::new(SchemaState::String(StringType::Unknown {
-                    strings_seen: std::collections::HashSet::from_iter([
+                    strings_seen: vec![
                         "foo".to_owned(),
                         "barbar".to_owned()
-                    ]),
+                    ],
                     chars_seen: vec!['f', 'o', 'o', 'b', 'a', 'r', 'b', 'a', 'r'],
                     min_length: Some(3),
                     max_length: Some(6)
@@ -744,7 +744,7 @@ mod tests {
                 min_length: 2,
                 max_length: 2,
                 schema: Box::new(SchemaState::String(StringType::Unknown {
-                    strings_seen: std::collections::HashSet::from_iter(["barbar".to_owned()]),
+                    strings_seen: vec!["barbar".to_owned()],
                     chars_seen: vec!['b', 'a', 'r', 'b', 'a', 'r'],
                     min_length: Some(6),
                     max_length: Some(6),
@@ -854,10 +854,10 @@ mod tests {
                     optional: std::collections::HashMap::from_iter([(
                         "foo".to_owned(),
                         SchemaState::String(StringType::Unknown {
-                            strings_seen: std::collections::HashSet::from_iter([
+                            strings_seen: vec![
                                 "bar".to_owned(),
                                 "barbar".to_owned()
-                            ]),
+                            ],
                             chars_seen: vec!['b', 'a', 'r', 'b', 'a', 'r', 'b', 'a', 'r'],
                             min_length: Some(3),
                             max_length: Some(6)
@@ -950,7 +950,7 @@ mod tests {
                 max_length: 2,
                 schema: Box::new(SchemaState::Nullable(Box::new(SchemaState::String(
                     StringType::Unknown {
-                        strings_seen: std::collections::HashSet::from_iter(["foo".to_owned()]),
+                        strings_seen: vec!["foo".to_owned()],
                         chars_seen: vec!['f', 'o', 'o'],
                         min_length: Some(3),
                         max_length: Some(3)
@@ -1000,10 +1000,10 @@ mod tests {
                 optional: std::collections::HashMap::from_iter([(
                     "foo".to_owned(),
                     SchemaState::String(StringType::Unknown {
-                        strings_seen: std::collections::HashSet::from_iter([
+                        strings_seen: vec![
                             "bar".to_owned(),
                             "barbar".to_owned()
-                        ]),
+                        ],
                         chars_seen: vec!['b', 'a', 'r', 'b', 'a', 'r', 'b', 'a', 'r'],
                         min_length: Some(3),
                         max_length: Some(6)

--- a/src/infer_string.rs
+++ b/src/infer_string.rs
@@ -28,6 +28,7 @@ pub(crate) fn infer_string_type(s: &str) -> StringType {
         StringType::Hostname
     } else {
         StringType::Unknown {
+            strings_seen: std::collections::HashSet::from_iter([s.to_owned()]),
             chars_seen: s.chars().collect(),
             min_length: Some(s.len()),
             max_length: Some(s.len()),

--- a/src/infer_string.rs
+++ b/src/infer_string.rs
@@ -28,7 +28,7 @@ pub(crate) fn infer_string_type(s: &str) -> StringType {
         StringType::Hostname
     } else {
         StringType::Unknown {
-            strings_seen: std::collections::HashSet::from_iter([s.to_owned()]),
+            strings_seen: vec![s.to_owned()],
             chars_seen: s.chars().collect(),
             min_length: Some(s.len()),
             max_length: Some(s.len()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,9 +33,13 @@ fn main() {
             std::process::exit(1)
         }
     };
+    
+    let opts = drivel::InferenceOptions {
+        enum_inference: None,
+    };
 
     let schema = if let Ok(json) = serde_json::from_str(&input) {
-        drivel::infer_schema(json)
+        drivel::infer_schema(json, &opts)
     } else {
         // unable to parse input as JSON; try JSON lines format as fallback
         let values = input
@@ -51,7 +55,7 @@ fn main() {
                 }
             })
             .collect();
-        drivel::infer_schema_from_iter(values)
+        drivel::infer_schema_from_iter(values, &opts)
     };
 
     match &args.mode {

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ struct Args {
     #[arg(long, global=true)]
     enum_max_uniq: Option<f64>,
 
-    /// The minimum number of strings to consider when inferring enums. Default = 1.
+    /// The minimum sample size of strings before enum inference will be attempted. Default = 1.
     #[arg(long, global=true)]
     enum_min_n: Option<usize>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
             std::process::exit(1)
         }
     };
-    
+
     let opts = drivel::InferenceOptions {
         enum_inference: None,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,36 @@ enum Mode {
 struct Args {
     #[command(subcommand)]
     mode: Mode,
+
+    /// Infer that some string fields are enums based on the number of unique values seen.
+    #[arg(long, global=true)]
+    infer_enum: bool,
+
+    /// The maximum ratio of unique values to total values for a field to be considered an enum. Default = 0.1.
+    #[arg(long, global=true)]
+    enum_max_uniq: Option<f64>,
+
+    /// The minimum number of strings to consider when inferring enums. Default = 1.
+    #[arg(long, global=true)]
+    enum_min_n: Option<usize>,
 }
+
+impl From<&Args> for Option<drivel::EnumInference> {
+    fn from(value: &Args) -> Self {
+        if value.infer_enum {
+            let max_unique_ratio = value.enum_max_uniq.unwrap_or(0.1);
+            let min_sample_size = value.enum_min_n.unwrap_or(1);
+            Some(
+                drivel::EnumInference {
+                    max_unique_ratio,
+                    min_sample_size,
+                }
+            )
+        } else {
+            None
+        }
+    }
+} 
 
 fn main() {
     let args = Args::parse();
@@ -35,7 +64,7 @@ fn main() {
     };
 
     let opts = drivel::InferenceOptions {
-        enum_inference: None,
+        enum_inference: (&args).into(),
     };
 
     let schema = if let Ok(json) = serde_json::from_str(&input) {

--- a/src/produce.rs
+++ b/src/produce.rs
@@ -65,6 +65,7 @@ fn produce_inner(schema: &SchemaState, repeat_n: usize, current_depth: usize) ->
                     chars_seen,
                     min_length,
                     max_length,
+                    ..
                 } => {
                     let min = min_length.unwrap_or(0);
                     let max = max_length.unwrap_or(32);

--- a/src/produce.rs
+++ b/src/produce.rs
@@ -89,6 +89,11 @@ fn produce_inner(schema: &SchemaState, repeat_n: usize, current_depth: usize) ->
                         s
                     }
                 }
+                StringType::Enum { variants } => {
+                    let variants_vec = variants.iter().cloned().collect::<Vec<_>>();
+                    let idx = thread_rng().gen_range(0..variants_vec.len());
+                    variants_vec[idx].clone()
+                }
             };
             serde_json::Value::String(value)
         }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -211,6 +211,7 @@ impl SchemaState {
     ///
     /// let required = HashMap::from_iter(vec![
     ///     ("name".to_string(), SchemaState::String(StringType::Unknown {
+    ///         strings_seen: vec!["abc".to_string()],
     ///         chars_seen: vec!['a', 'b', 'c'],
     ///         min_length: Some(1),
     ///         max_length: Some(10),

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -14,6 +14,7 @@ pub enum StringType {
     Email,
     Url,
     Hostname,
+    Enum { variants: std::collections::HashSet<String> }
 }
 
 impl Display for StringType {
@@ -45,6 +46,11 @@ impl Display for StringType {
             StringType::Email => "string (email)".to_owned(),
             StringType::Hostname => "string (hostname)".to_owned(),
             StringType::Url => "string (url)".to_owned(),
+            StringType::Enum { variants } => {
+                let variants_vec = variants.iter().cloned().collect::<Vec<_>>();
+                let formatted = variants_vec.join(", ");
+                format!("string (enum: {})", formatted)
+            }
         };
         write!(f, "{}", text)
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 #[derive(PartialEq, Debug)]
 pub enum StringType {
     Unknown {
+        strings_seen: std::collections::HashSet<String>,
         chars_seen: Vec<char>,
         min_length: Option<usize>,
         max_length: Option<usize>,
@@ -14,13 +15,16 @@ pub enum StringType {
     Email,
     Url,
     Hostname,
-    Enum { variants: std::collections::HashSet<String> }
+    Enum {
+        variants: std::collections::HashSet<String>,
+    },
 }
 
 impl Display for StringType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let text = match self {
             StringType::Unknown {
+                strings_seen: _,
                 chars_seen: _,
                 min_length,
                 max_length,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 #[derive(PartialEq, Debug)]
 pub enum StringType {
     Unknown {
-        strings_seen: std::collections::HashSet<String>,
+        strings_seen: Vec<String>,
         chars_seen: Vec<char>,
         min_length: Option<usize>,
         max_length: Option<usize>,


### PR DESCRIPTION
Closes #5 

Adds a command line option to infer enums from strings, with the ability for a user to specify what ratio of unique strings they want to consider the "cutoff" for thinking of a string as an enum, as well as a minimum sample size.