### PR TITLE
perf: Optimise string inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "drivel"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "drivel"
 description = "Infer a schema from JSON input, and generate synthetic data based on the inferred schema."
 license = "MIT"
 authors = ["Daniël Hogers <daniel@hgrsd.nl>"]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 repository = "https://github.com/hgrsd/drivel"
 


### PR DESCRIPTION
Using some basic heuristics, we can decrease the amount of regex matching that we do. This leads to a significant (15-20% in some local benchmarks) speedup for large data sets, depending on how many strings are matches for the specific stringtypes.