### PR TITLE
feat: infer JSON schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /target
-CLAUDE.md

--- a/src/infer.rs
+++ b/src/infer.rs
@@ -518,7 +518,7 @@ mod tests {
         };
         let schema = infer_schema(input, &options);
 
-        assert_eq!(schema, SchemaState::String(StringType::DateTimeISO8601))
+        assert_eq!(schema, SchemaState::String(StringType::DateTimeRFC2822))
     }
 
     #[test]

--- a/src/infer_string.rs
+++ b/src/infer_string.rs
@@ -50,7 +50,7 @@ fn dates(s: &str) -> Option<StringType> {
     }
 
     if chrono::DateTime::parse_from_rfc2822(s).is_ok() {
-        return Some(StringType::DateTimeISO8601);
+        return Some(StringType::DateTimeRFC2822);
     }
 
     None

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use drivel::SchemaState;
+use drivel::{SchemaState, ToJsonSchema};
 use jemallocator::Jemalloc;
 
 #[global_allocator]
@@ -8,7 +8,11 @@ static GLOBAL: Jemalloc = Jemalloc;
 #[derive(Subcommand, Debug)]
 enum Mode {
     /// Describe the inferred schema for the input data
-    Describe,
+    Describe {
+        /// Output JSON Schema format instead of human-readable description
+        #[arg(long)]
+        json_schema: bool,
+    },
     /// Produce synthetic data adhering to the inferred schema
     Produce {
         #[arg(short, long)]
@@ -110,8 +114,14 @@ fn main() {
             let stdout = std::io::stdout();
             serde_json::to_writer_pretty(stdout, &result).unwrap();
         }
-        Mode::Describe => {
-            println!("{}", schema.to_string_pretty());
+        Mode::Describe { json_schema } => {
+            if *json_schema {
+                let json_schema = schema.to_json_schema_document();
+                let stdout = std::io::stdout();
+                serde_json::to_writer_pretty(stdout, &json_schema).unwrap();
+            } else {
+                println!("{}", schema.to_string_pretty());
+            }
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -416,8 +416,13 @@ mod tests {
         }
 
         pub fn enum_string(variants: Vec<&str>) -> StringType {
-            let variant_set = variants.iter().map(|s| s.to_string()).collect::<HashSet<_>>();
-            StringType::Enum { variants: variant_set }
+            let variant_set = variants
+                .iter()
+                .map(|s| s.to_string())
+                .collect::<HashSet<_>>();
+            StringType::Enum {
+                variants: variant_set,
+            }
         }
 
         pub fn integer_range(min: i64, max: i64) -> NumberType {
@@ -440,7 +445,11 @@ mod tests {
             SchemaState::Nullable(Box::new(inner))
         }
 
-        pub fn array_schema(min_length: usize, max_length: usize, item_schema: SchemaState) -> SchemaState {
+        pub fn array_schema(
+            min_length: usize,
+            max_length: usize,
+            item_schema: SchemaState,
+        ) -> SchemaState {
             SchemaState::Array {
                 min_length,
                 max_length,
@@ -456,7 +465,7 @@ mod tests {
                 .into_iter()
                 .map(|(k, v)| (k.to_string(), v))
                 .collect::<HashMap<_, _>>();
-            
+
             let optional = optional_fields
                 .into_iter()
                 .map(|(k, v)| (k.to_string(), v))
@@ -471,8 +480,8 @@ mod tests {
     }
 
     mod json_schema_tests {
-        use super::*;
         use super::test_helpers::*;
+        use super::*;
 
         mod basic_types {
             use super::*;
@@ -504,11 +513,14 @@ mod tests {
             #[test]
             fn unknown_string_with_length_constraints_to_json_schema() {
                 let schema = string_schema(unknown_string(Some(3), Some(10)));
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "minLength": 3,
-                    "maxLength": 10
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "minLength": 3,
+                        "maxLength": 10
+                    }),
+                );
             }
 
             #[test]
@@ -520,84 +532,111 @@ mod tests {
             #[test]
             fn unknown_string_min_only_to_json_schema() {
                 let schema = string_schema(unknown_string(Some(5), None));
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "minLength": 5
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "minLength": 5
+                    }),
+                );
             }
 
             #[test]
             fn unknown_string_max_only_to_json_schema() {
                 let schema = string_schema(unknown_string(None, Some(20)));
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "maxLength": 20
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "maxLength": 20
+                    }),
+                );
             }
 
             #[test]
             fn uuid_string_to_json_schema() {
                 let schema = string_schema(StringType::UUID);
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "format": "uuid"
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "format": "uuid"
+                    }),
+                );
             }
 
             #[test]
             fn email_string_to_json_schema() {
                 let schema = string_schema(StringType::Email);
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "format": "email"
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "format": "email"
+                    }),
+                );
             }
 
             #[test]
             fn url_string_to_json_schema() {
                 let schema = string_schema(StringType::Url);
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "format": "uri"
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "format": "uri"
+                    }),
+                );
             }
 
             #[test]
             fn iso_date_string_to_json_schema() {
                 let schema = string_schema(StringType::IsoDate);
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "format": "date"
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "format": "date"
+                    }),
+                );
             }
 
             #[test]
             fn datetime_iso8601_string_to_json_schema() {
                 let schema = string_schema(StringType::DateTimeISO8601);
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "format": "date-time"
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "format": "date-time"
+                    }),
+                );
             }
 
             #[test]
             fn hostname_string_to_json_schema() {
                 let schema = string_schema(StringType::Hostname);
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "format": "hostname",
-                    "x-drivel-type": "hostname"
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "format": "hostname",
+                        "x-drivel-type": "hostname"
+                    }),
+                );
             }
 
             #[test]
             fn datetime_rfc2822_string_to_json_schema() {
                 let schema = string_schema(StringType::DateTimeRFC2822);
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "x-drivel-type": "datetime-rfc2822",
-                    "description": "RFC 2822 datetime format"
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "x-drivel-type": "datetime-rfc2822",
+                        "description": "RFC 2822 datetime format"
+                    }),
+                );
             }
 
             #[test]
@@ -613,19 +652,25 @@ mod tests {
             #[test]
             fn enum_string_single_variant_to_json_schema() {
                 let schema = string_schema(enum_string(vec!["only"]));
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "enum": ["only"]
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "enum": ["only"]
+                    }),
+                );
             }
 
             #[test]
             fn enum_string_empty_variants_to_json_schema() {
                 let schema = string_schema(enum_string(vec![]));
-                assert_schema_equals(&schema, json!({
-                    "type": "string",
-                    "enum": []
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "string",
+                        "enum": []
+                    }),
+                );
             }
         }
 
@@ -635,71 +680,92 @@ mod tests {
             #[test]
             fn integer_range_to_json_schema() {
                 let schema = number_schema(integer_range(1, 100));
-                assert_schema_equals(&schema, json!({
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 100
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100
+                    }),
+                );
             }
 
             #[test]
             fn integer_single_value_to_json_schema() {
                 let schema = number_schema(integer_range(42, 42));
-                assert_schema_equals(&schema, json!({
-                    "type": "integer",
-                    "minimum": 42,
-                    "maximum": 42
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "integer",
+                        "minimum": 42,
+                        "maximum": 42
+                    }),
+                );
             }
 
             #[test]
             fn integer_negative_range_to_json_schema() {
                 let schema = number_schema(integer_range(-100, -10));
-                assert_schema_equals(&schema, json!({
-                    "type": "integer",
-                    "minimum": -100,
-                    "maximum": -10
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "integer",
+                        "minimum": -100,
+                        "maximum": -10
+                    }),
+                );
             }
 
             #[test]
             fn integer_zero_range_to_json_schema() {
                 let schema = number_schema(integer_range(0, 0));
-                assert_schema_equals(&schema, json!({
-                    "type": "integer",
-                    "minimum": 0,
-                    "maximum": 0
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "integer",
+                        "minimum": 0,
+                        "maximum": 0
+                    }),
+                );
             }
 
             #[test]
             fn float_range_to_json_schema() {
                 let schema = number_schema(float_range(1.5, 99.9));
-                assert_schema_equals(&schema, json!({
-                    "type": "number",
-                    "minimum": 1.5,
-                    "maximum": 99.9
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "number",
+                        "minimum": 1.5,
+                        "maximum": 99.9
+                    }),
+                );
             }
 
             #[test]
             fn float_single_value_to_json_schema() {
                 let schema = number_schema(float_range(3.14, 3.14));
-                assert_schema_equals(&schema, json!({
-                    "type": "number",
-                    "minimum": 3.14,
-                    "maximum": 3.14
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "number",
+                        "minimum": 3.14,
+                        "maximum": 3.14
+                    }),
+                );
             }
 
             #[test]
             fn float_negative_range_to_json_schema() {
                 let schema = number_schema(float_range(-99.9, -1.1));
-                assert_schema_equals(&schema, json!({
-                    "type": "number",
-                    "minimum": -99.9,
-                    "maximum": -1.1
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "number",
+                        "minimum": -99.9,
+                        "maximum": -1.1
+                    }),
+                );
             }
         }
 
@@ -709,41 +775,50 @@ mod tests {
             #[test]
             fn nullable_string_to_json_schema() {
                 let schema = nullable_schema(string_schema(StringType::UUID));
-                assert_schema_equals(&schema, json!({
-                    "type": ["string", "null"],
-                    "format": "uuid"
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": ["string", "null"],
+                        "format": "uuid"
+                    }),
+                );
             }
 
             #[test]
             fn nullable_integer_to_json_schema() {
                 let schema = nullable_schema(number_schema(integer_range(1, 10)));
-                assert_schema_equals(&schema, json!({
-                    "type": ["integer", "null"],
-                    "minimum": 1,
-                    "maximum": 10
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": ["integer", "null"],
+                        "minimum": 1,
+                        "maximum": 10
+                    }),
+                );
             }
 
             #[test]
             fn nullable_array_to_json_schema() {
                 let schema = nullable_schema(array_schema(1, 3, string_schema(StringType::Email)));
-                assert_schema_equals(&schema, json!({
-                    "type": ["array", "null"],
-                    "items": {
-                        "type": "string",
-                        "format": "email"
-                    },
-                    "minItems": 1,
-                    "maxItems": 3
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": ["array", "null"],
+                        "items": {
+                            "type": "string",
+                            "format": "email"
+                        },
+                        "minItems": 1,
+                        "maxItems": 3
+                    }),
+                );
             }
 
             #[test]
             fn nullable_object_to_json_schema() {
                 let schema = nullable_schema(object_schema(
                     vec![("id", number_schema(integer_range(1, 100)))],
-                    vec![]
+                    vec![],
                 ));
                 let result = schema.to_json_schema();
                 assert_eq!(result["type"], json!(["object", "null"]));
@@ -759,34 +834,44 @@ mod tests {
             #[test]
             fn array_with_constraints_to_json_schema() {
                 let schema = array_schema(1, 5, string_schema(StringType::UUID));
-                assert_schema_equals(&schema, json!({
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "format": "uuid"
-                    },
-                    "minItems": 1,
-                    "maxItems": 5
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "minItems": 1,
+                        "maxItems": 5
+                    }),
+                );
             }
 
             #[test]
             fn empty_array_to_json_schema() {
                 let schema = array_schema(0, 0, SchemaState::Boolean);
-                assert_schema_equals(&schema, json!({
-                    "type": "array",
-                    "items": { "type": "boolean" },
-                    "minItems": 0,
-                    "maxItems": 0
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "array",
+                        "items": { "type": "boolean" },
+                        "minItems": 0,
+                        "maxItems": 0
+                    }),
+                );
             }
 
             #[test]
             fn array_of_objects_to_json_schema() {
-                let schema = array_schema(1, 10, object_schema(
-                    vec![("name", string_schema(unknown_string(Some(1), Some(50))))],
-                    vec![]
-                ));
+                let schema = array_schema(
+                    1,
+                    10,
+                    object_schema(
+                        vec![("name", string_schema(unknown_string(Some(1), Some(50))))],
+                        vec![],
+                    ),
+                );
                 let result = schema.to_json_schema();
                 assert_eq!(result["type"], "array");
                 assert_eq!(result["minItems"], 1);
@@ -797,7 +882,11 @@ mod tests {
 
             #[test]
             fn nested_array_to_json_schema() {
-                let schema = array_schema(1, 3, array_schema(2, 4, number_schema(integer_range(1, 100))));
+                let schema = array_schema(
+                    1,
+                    3,
+                    array_schema(2, 4, number_schema(integer_range(1, 100))),
+                );
                 let result = schema.to_json_schema();
                 assert_eq!(result["type"], "array");
                 assert_eq!(result["items"]["type"], "array");
@@ -816,7 +905,7 @@ mod tests {
             fn object_with_required_and_optional_to_json_schema() {
                 let schema = object_schema(
                     vec![("id", number_schema(integer_range(1, 1000)))],
-                    vec![("name", string_schema(unknown_string(Some(1), Some(50))))]
+                    vec![("name", string_schema(unknown_string(Some(1), Some(50))))],
                 );
                 let result = schema.to_json_schema();
 
@@ -830,12 +919,15 @@ mod tests {
             #[test]
             fn empty_object_to_json_schema() {
                 let schema = object_schema(vec![], vec![]);
-                assert_schema_equals(&schema, json!({
-                    "type": "object",
-                    "additionalProperties": false,
-                    "required": [],
-                    "properties": {}
-                }));
+                assert_schema_equals(
+                    &schema,
+                    json!({
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [],
+                        "properties": {}
+                    }),
+                );
             }
 
             #[test]
@@ -843,15 +935,21 @@ mod tests {
                 let schema = object_schema(
                     vec![
                         ("id", number_schema(integer_range(1, 100))),
-                        ("status", SchemaState::Boolean)
+                        ("status", SchemaState::Boolean),
                     ],
-                    vec![]
+                    vec![],
                 );
                 let result = schema.to_json_schema();
                 assert_eq!(result["type"], "object");
                 assert_eq!(result["required"].as_array().unwrap().len(), 2);
-                assert!(result["required"].as_array().unwrap().contains(&json!("id")));
-                assert!(result["required"].as_array().unwrap().contains(&json!("status")));
+                assert!(result["required"]
+                    .as_array()
+                    .unwrap()
+                    .contains(&json!("id")));
+                assert!(result["required"]
+                    .as_array()
+                    .unwrap()
+                    .contains(&json!("status")));
             }
 
             #[test]
@@ -860,8 +958,8 @@ mod tests {
                     vec![],
                     vec![
                         ("description", string_schema(unknown_string(None, None))),
-                        ("count", number_schema(integer_range(0, 10)))
-                    ]
+                        ("count", number_schema(integer_range(0, 10))),
+                    ],
                 );
                 let result = schema.to_json_schema();
                 assert_eq!(result["type"], "object");
@@ -874,12 +972,9 @@ mod tests {
             fn nested_object_to_json_schema() {
                 let inner_object = object_schema(
                     vec![("nested_id", number_schema(integer_range(1, 10)))],
-                    vec![]
+                    vec![],
                 );
-                let schema = object_schema(
-                    vec![("inner", inner_object)],
-                    vec![]
-                );
+                let schema = object_schema(vec![("inner", inner_object)], vec![]);
                 let result = schema.to_json_schema();
                 assert_eq!(result["type"], "object");
                 assert_eq!(result["properties"]["inner"]["type"], "object");

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -442,53 +442,6 @@ mod tests {
         assert_eq!(document["type"], "boolean");
     }
 
-    #[test]
-    fn json_schema_document_edge_cases() {
-        // Test document format with Initial state (empty schema)
-        let initial_schema = SchemaState::Initial;
-        let document = initial_schema.to_json_schema_document();
-
-        assert_eq!(
-            document["$schema"],
-            "https://json-schema.org/draft/2020-12/schema"
-        );
-        assert_eq!(document["$id"], "https://example.com/schema");
-        assert_eq!(document["title"], "Inferred Schema");
-        assert_eq!(
-            document["description"],
-            "Schema inferred by drivel from sample data"
-        );
-        // Should not have a "type" field since Initial produces empty schema
-        assert!(document.get("type").is_none());
-
-        // Test document format with complex nested structure
-        use std::collections::HashMap;
-        let mut required = HashMap::new();
-        required.insert(
-            "items".to_string(),
-            SchemaState::Array {
-                min_length: 1,
-                max_length: 10,
-                schema: Box::new(SchemaState::Nullable(Box::new(SchemaState::String(
-                    StringType::UUID,
-                )))),
-            },
-        );
-
-        let complex_schema = SchemaState::Object {
-            required,
-            optional: HashMap::new(),
-        };
-        let document = complex_schema.to_json_schema_document();
-
-        assert_eq!(document["type"], "object");
-        assert_eq!(document["properties"]["items"]["type"], "array");
-        assert_eq!(
-            document["properties"]["items"]["items"]["type"],
-            json!(["string", "null"])
-        );
-        assert_eq!(document["properties"]["items"]["items"]["format"], "uuid");
-    }
 
     #[test]
     fn string_types_to_json_schema() {

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,5 +1,26 @@
 use std::fmt::Display;
 
+pub trait ToJsonSchema {
+    fn to_json_schema(&self) -> serde_json::Value;
+    
+    fn to_json_schema_document(&self) -> serde_json::Value {
+        let mut doc = serde_json::json!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": "https://example.com/schema",
+            "title": "Inferred Schema",
+            "description": "Schema inferred by drivel from sample data"
+        });
+        
+        if let serde_json::Value::Object(schema_obj) = self.to_json_schema() {
+            if let serde_json::Value::Object(doc_obj) = &mut doc {
+                doc_obj.extend(schema_obj);
+            }
+        }
+        
+        doc
+    }
+}
+
 #[derive(PartialEq, Debug)]
 pub enum StringType {
     Unknown {
@@ -240,5 +261,710 @@ impl SchemaState {
     /// ```
     pub fn to_string_pretty(&self) -> String {
         to_string_pretty_inner(self, 0)
+    }
+}
+
+impl ToJsonSchema for SchemaState {
+    fn to_json_schema(&self) -> serde_json::Value {
+        match self {
+            SchemaState::Boolean => serde_json::json!({ "type": "boolean" }),
+            SchemaState::Null => serde_json::json!({ "type": "null" }),
+            SchemaState::Initial | SchemaState::Indefinite => serde_json::json!({}),
+            SchemaState::String(string_type) => string_type.to_json_schema(),
+            SchemaState::Number(number_type) => number_type.to_json_schema(),
+            SchemaState::Nullable(inner) => {
+                let mut inner_schema = inner.to_json_schema();
+                
+                // Convert single type to array with null
+                if let Some(type_value) = inner_schema.get("type") {
+                    if let Some(type_str) = type_value.as_str() {
+                        inner_schema["type"] = serde_json::json!([type_str, "null"]);
+                    }
+                }
+                
+                inner_schema
+            },
+            SchemaState::Array { min_length, max_length, schema } => {
+                serde_json::json!({
+                    "type": "array",
+                    "items": schema.to_json_schema(),
+                    "minItems": min_length,
+                    "maxItems": max_length
+                })
+            },
+            SchemaState::Object { required, optional } => {
+                let mut properties = serde_json::Map::new();
+                let mut required_fields = Vec::new();
+                
+                // Add required fields
+                for (key, schema) in required {
+                    properties.insert(key.clone(), schema.to_json_schema());
+                    required_fields.push(key.clone());
+                }
+                
+                // Add optional fields
+                for (key, schema) in optional {
+                    properties.insert(key.clone(), schema.to_json_schema());
+                }
+                
+                serde_json::json!({
+                    "type": "object",
+                    "properties": properties,
+                    "required": required_fields,
+                    "additionalProperties": false
+                })
+            }
+        }
+    }
+}
+
+impl ToJsonSchema for StringType {
+    fn to_json_schema(&self) -> serde_json::Value {
+        match self {
+            StringType::Unknown { min_length, max_length, .. } => {
+                let mut schema = serde_json::json!({ "type": "string" });
+                if let Some(min) = min_length {
+                    schema["minLength"] = serde_json::Value::Number((*min).into());
+                }
+                if let Some(max) = max_length {
+                    schema["maxLength"] = serde_json::Value::Number((*max).into());
+                }
+                schema
+            }
+            StringType::UUID => serde_json::json!({
+                "type": "string",
+                "format": "uuid"
+            }),
+            StringType::Email => serde_json::json!({
+                "type": "string",
+                "format": "email"
+            }),
+            StringType::Url => serde_json::json!({
+                "type": "string",
+                "format": "uri"
+            }),
+            StringType::IsoDate => serde_json::json!({
+                "type": "string",
+                "format": "date"
+            }),
+            StringType::DateTimeISO8601 => serde_json::json!({
+                "type": "string",
+                "format": "date-time"
+            }),
+            StringType::Hostname => serde_json::json!({
+                "type": "string",
+                "format": "hostname",
+                "x-drivel-type": "hostname"
+            }),
+            StringType::DateTimeRFC2822 => serde_json::json!({
+                "type": "string",
+                "x-drivel-type": "datetime-rfc2822",
+                "description": "RFC 2822 datetime format"
+            }),
+            StringType::Enum { variants } => {
+                let enum_values: Vec<&String> = variants.iter().collect();
+                serde_json::json!({
+                    "type": "string",
+                    "enum": enum_values
+                })
+            }
+        }
+    }
+}
+
+impl ToJsonSchema for NumberType {
+    fn to_json_schema(&self) -> serde_json::Value {
+        match self {
+            NumberType::Integer { min, max } => serde_json::json!({
+                "type": "integer",
+                "minimum": min,
+                "maximum": max
+            }),
+            NumberType::Float { min, max } => serde_json::json!({
+                "type": "number",
+                "minimum": min,
+                "maximum": max
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn basic_types_to_json_schema() {
+        // Test Boolean
+        let boolean_schema = SchemaState::Boolean;
+        assert_eq!(
+            boolean_schema.to_json_schema(),
+            json!({ "type": "boolean" })
+        );
+
+        // Test Null
+        let null_schema = SchemaState::Null;
+        assert_eq!(
+            null_schema.to_json_schema(),
+            json!({ "type": "null" })
+        );
+
+        // Test Initial state (should be empty schema)
+        let initial_schema = SchemaState::Initial;
+        assert_eq!(
+            initial_schema.to_json_schema(),
+            json!({})
+        );
+
+        // Test Indefinite state (should be empty schema)
+        let indefinite_schema = SchemaState::Indefinite;
+        assert_eq!(
+            indefinite_schema.to_json_schema(),
+            json!({})
+        );
+    }
+
+    #[test]
+    fn json_schema_document_format() {
+        let boolean_schema = SchemaState::Boolean;
+        let document = boolean_schema.to_json_schema_document();
+        
+        assert_eq!(document["$schema"], "https://json-schema.org/draft/2020-12/schema");
+        assert_eq!(document["$id"], "https://example.com/schema");
+        assert_eq!(document["title"], "Inferred Schema");
+        assert_eq!(document["description"], "Schema inferred by drivel from sample data");
+        assert_eq!(document["type"], "boolean");
+    }
+
+    #[test]
+    fn json_schema_document_edge_cases() {
+        // Test document format with Initial state (empty schema)
+        let initial_schema = SchemaState::Initial;
+        let document = initial_schema.to_json_schema_document();
+        
+        assert_eq!(document["$schema"], "https://json-schema.org/draft/2020-12/schema");
+        assert_eq!(document["$id"], "https://example.com/schema");
+        assert_eq!(document["title"], "Inferred Schema");
+        assert_eq!(document["description"], "Schema inferred by drivel from sample data");
+        // Should not have a "type" field since Initial produces empty schema
+        assert!(document.get("type").is_none());
+
+        // Test document format with complex nested structure
+        use std::collections::HashMap;
+        let mut required = HashMap::new();
+        required.insert("items".to_string(), SchemaState::Array {
+            min_length: 1,
+            max_length: 10,
+            schema: Box::new(SchemaState::Nullable(Box::new(SchemaState::String(StringType::UUID)))),
+        });
+        
+        let complex_schema = SchemaState::Object { required, optional: HashMap::new() };
+        let document = complex_schema.to_json_schema_document();
+        
+        assert_eq!(document["type"], "object");
+        assert_eq!(document["properties"]["items"]["type"], "array");
+        assert_eq!(document["properties"]["items"]["items"]["type"], json!(["string", "null"]));
+        assert_eq!(document["properties"]["items"]["items"]["format"], "uuid");
+    }
+
+    #[test]
+    fn string_types_to_json_schema() {
+        // Test basic string with length constraints
+        let unknown_string = SchemaState::String(StringType::Unknown {
+            strings_seen: vec!["test".to_string()],
+            chars_seen: vec!['t', 'e', 's', 't'],
+            min_length: Some(3),
+            max_length: Some(10),
+        });
+        assert_eq!(
+            unknown_string.to_json_schema(),
+            json!({
+                "type": "string",
+                "minLength": 3,
+                "maxLength": 10
+            })
+        );
+
+        // Test UUID
+        let uuid_string = SchemaState::String(StringType::UUID);
+        assert_eq!(
+            uuid_string.to_json_schema(),
+            json!({
+                "type": "string",
+                "format": "uuid"
+            })
+        );
+
+        // Test Email
+        let email_string = SchemaState::String(StringType::Email);
+        assert_eq!(
+            email_string.to_json_schema(),
+            json!({
+                "type": "string",
+                "format": "email"
+            })
+        );
+    }
+
+    #[test]
+    fn string_no_length_constraints_to_json_schema() {
+        let no_constraints = SchemaState::String(StringType::Unknown {
+            strings_seen: vec!["test".to_string()],
+            chars_seen: vec!['t', 'e', 's', 't'],
+            min_length: None,
+            max_length: None,
+        });
+        assert_eq!(
+            no_constraints.to_json_schema(),
+            json!({ "type": "string" })
+        );
+    }
+
+    #[test]
+    fn string_min_length_only_to_json_schema() {
+        let min_only = SchemaState::String(StringType::Unknown {
+            strings_seen: vec!["test".to_string()],
+            chars_seen: vec!['t', 'e', 's', 't'],
+            min_length: Some(5),
+            max_length: None,
+        });
+        assert_eq!(
+            min_only.to_json_schema(),
+            json!({
+                "type": "string",
+                "minLength": 5
+            })
+        );
+    }
+
+    #[test]
+    fn string_max_length_only_to_json_schema() {
+        let max_only = SchemaState::String(StringType::Unknown {
+            strings_seen: vec!["test".to_string()],
+            chars_seen: vec!['t', 'e', 's', 't'],
+            min_length: None,
+            max_length: Some(20),
+        });
+        assert_eq!(
+            max_only.to_json_schema(),
+            json!({
+                "type": "string",
+                "maxLength": 20
+            })
+        );
+    }
+
+    #[test]
+    fn string_format_types_to_json_schema() {
+        assert_eq!(
+            SchemaState::String(StringType::Url).to_json_schema(),
+            json!({ "type": "string", "format": "uri" })
+        );
+
+        assert_eq!(
+            SchemaState::String(StringType::IsoDate).to_json_schema(),
+            json!({ "type": "string", "format": "date" })
+        );
+
+        assert_eq!(
+            SchemaState::String(StringType::DateTimeISO8601).to_json_schema(),
+            json!({ "type": "string", "format": "date-time" })
+        );
+
+        assert_eq!(
+            SchemaState::String(StringType::Hostname).to_json_schema(),
+            json!({
+                "type": "string",
+                "format": "hostname",
+                "x-drivel-type": "hostname"
+            })
+        );
+
+        assert_eq!(
+            SchemaState::String(StringType::DateTimeRFC2822).to_json_schema(),
+            json!({
+                "type": "string",
+                "x-drivel-type": "datetime-rfc2822",
+                "description": "RFC 2822 datetime format"
+            })
+        );
+    }
+
+    #[test]
+    fn string_enum_multiple_variants_to_json_schema() {
+        let mut enum_variants = std::collections::HashSet::new();
+        enum_variants.insert("red".to_string());
+        enum_variants.insert("green".to_string());
+        enum_variants.insert("blue".to_string());
+        
+        let enum_string = SchemaState::String(StringType::Enum { variants: enum_variants });
+        let result = enum_string.to_json_schema();
+        assert_eq!(result["type"], "string");
+        assert!(result["enum"].is_array());
+        let enum_values = result["enum"].as_array().unwrap();
+        assert_eq!(enum_values.len(), 3);
+    }
+
+    #[test]
+    fn string_enum_empty_variants_to_json_schema() {
+        let empty_enum = SchemaState::String(StringType::Enum { 
+            variants: std::collections::HashSet::new() 
+        });
+        let result = empty_enum.to_json_schema();
+        assert_eq!(result["type"], "string");
+        assert_eq!(result["enum"], json!([]));
+    }
+
+    #[test]
+    fn string_enum_single_variant_to_json_schema() {
+        let mut single_variant = std::collections::HashSet::new();
+        single_variant.insert("only".to_string());
+        let single_enum = SchemaState::String(StringType::Enum { variants: single_variant });
+        let result = single_enum.to_json_schema();
+        assert_eq!(result["type"], "string");
+        assert_eq!(result["enum"], json!(["only"]));
+    }
+
+    #[test]
+    fn number_types_to_json_schema() {
+        // Test integer
+        let integer = SchemaState::Number(NumberType::Integer { min: 1, max: 100 });
+        assert_eq!(
+            integer.to_json_schema(),
+            json!({
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 100
+            })
+        );
+
+        // Test float
+        let float = SchemaState::Number(NumberType::Float { min: 1.5, max: 99.9 });
+        assert_eq!(
+            float.to_json_schema(),
+            json!({
+                "type": "number",
+                "minimum": 1.5,
+                "maximum": 99.9
+            })
+        );
+    }
+
+    #[test]
+    fn number_integer_single_value_to_json_schema() {
+        let single_value_int = SchemaState::Number(NumberType::Integer { min: 42, max: 42 });
+        assert_eq!(
+            single_value_int.to_json_schema(),
+            json!({
+                "type": "integer",
+                "minimum": 42,
+                "maximum": 42
+            })
+        );
+    }
+
+    #[test]
+    fn number_integer_negative_range_to_json_schema() {
+        let negative_int = SchemaState::Number(NumberType::Integer { min: -100, max: -10 });
+        assert_eq!(
+            negative_int.to_json_schema(),
+            json!({
+                "type": "integer",
+                "minimum": -100,
+                "maximum": -10
+            })
+        );
+    }
+
+    #[test]
+    fn number_integer_zero_range_to_json_schema() {
+        let zero_range = SchemaState::Number(NumberType::Integer { min: 0, max: 0 });
+        assert_eq!(
+            zero_range.to_json_schema(),
+            json!({
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 0
+            })
+        );
+    }
+
+    #[test]
+    fn number_float_single_value_to_json_schema() {
+        let single_value_float = SchemaState::Number(NumberType::Float { min: 3.14, max: 3.14 });
+        assert_eq!(
+            single_value_float.to_json_schema(),
+            json!({
+                "type": "number",
+                "minimum": 3.14,
+                "maximum": 3.14
+            })
+        );
+    }
+
+    #[test]
+    fn number_float_negative_range_to_json_schema() {
+        let negative_float = SchemaState::Number(NumberType::Float { min: -99.9, max: -1.1 });
+        assert_eq!(
+            negative_float.to_json_schema(),
+            json!({
+                "type": "number",
+                "minimum": -99.9,
+                "maximum": -1.1
+            })
+        );
+    }
+
+    #[test]
+    fn nullable_types_to_json_schema() {
+        // Test nullable string
+        let nullable_string = SchemaState::Nullable(Box::new(SchemaState::String(StringType::UUID)));
+        assert_eq!(
+            nullable_string.to_json_schema(),
+            json!({
+                "type": ["string", "null"],
+                "format": "uuid"
+            })
+        );
+
+        // Test nullable integer
+        let nullable_int = SchemaState::Nullable(Box::new(SchemaState::Number(NumberType::Integer { min: 1, max: 10 })));
+        assert_eq!(
+            nullable_int.to_json_schema(),
+            json!({
+                "type": ["integer", "null"],
+                "minimum": 1,
+                "maximum": 10
+            })
+        );
+    }
+
+    #[test]
+    fn nullable_array_to_json_schema() {
+        let nullable_array = SchemaState::Nullable(Box::new(SchemaState::Array {
+            min_length: 1,
+            max_length: 3,
+            schema: Box::new(SchemaState::String(StringType::Email)),
+        }));
+        assert_eq!(
+            nullable_array.to_json_schema(),
+            json!({
+                "type": ["array", "null"],
+                "items": {
+                    "type": "string",
+                    "format": "email"
+                },
+                "minItems": 1,
+                "maxItems": 3
+            })
+        );
+    }
+
+    #[test]
+    fn nullable_object_to_json_schema() {
+        use std::collections::HashMap;
+        let mut required = HashMap::new();
+        required.insert("id".to_string(), SchemaState::Number(NumberType::Integer { min: 1, max: 100 }));
+        
+        let nullable_object = SchemaState::Nullable(Box::new(SchemaState::Object {
+            required,
+            optional: HashMap::new(),
+        }));
+        let result = nullable_object.to_json_schema();
+        assert_eq!(result["type"], json!(["object", "null"]));
+        assert_eq!(result["properties"]["id"]["type"], "integer");
+        assert_eq!(result["required"], json!(["id"]));
+        assert_eq!(result["additionalProperties"], false);
+    }
+
+    #[test]
+    fn array_types_to_json_schema() {
+        let array_schema = SchemaState::Array {
+            min_length: 1,
+            max_length: 5,
+            schema: Box::new(SchemaState::String(StringType::UUID)),
+        };
+        assert_eq!(
+            array_schema.to_json_schema(),
+            json!({
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "format": "uuid"
+                },
+                "minItems": 1,
+                "maxItems": 5
+            })
+        );
+    }
+
+    #[test]
+    fn array_empty_to_json_schema() {
+        let empty_array = SchemaState::Array {
+            min_length: 0,
+            max_length: 0,
+            schema: Box::new(SchemaState::Boolean),
+        };
+        assert_eq!(
+            empty_array.to_json_schema(),
+            json!({
+                "type": "array",
+                "items": { "type": "boolean" },
+                "minItems": 0,
+                "maxItems": 0
+            })
+        );
+    }
+
+    #[test]
+    fn array_of_objects_to_json_schema() {
+        use std::collections::HashMap;
+        let mut required = HashMap::new();
+        required.insert("name".to_string(), SchemaState::String(StringType::Unknown {
+            strings_seen: vec!["test".to_string()],
+            chars_seen: vec!['t', 'e', 's', 't'],
+            min_length: Some(1),
+            max_length: Some(50),
+        }));
+
+        let array_of_objects = SchemaState::Array {
+            min_length: 1,
+            max_length: 10,
+            schema: Box::new(SchemaState::Object {
+                required,
+                optional: HashMap::new(),
+            }),
+        };
+        let result = array_of_objects.to_json_schema();
+        assert_eq!(result["type"], "array");
+        assert_eq!(result["minItems"], 1);
+        assert_eq!(result["maxItems"], 10);
+        assert_eq!(result["items"]["type"], "object");
+        assert_eq!(result["items"]["properties"]["name"]["type"], "string");
+    }
+
+    #[test]
+    fn array_nested_to_json_schema() {
+        let nested_array = SchemaState::Array {
+            min_length: 1,
+            max_length: 3,
+            schema: Box::new(SchemaState::Array {
+                min_length: 2,
+                max_length: 4,
+                schema: Box::new(SchemaState::Number(NumberType::Integer { min: 1, max: 100 })),
+            }),
+        };
+        let result = nested_array.to_json_schema();
+        assert_eq!(result["type"], "array");
+        assert_eq!(result["items"]["type"], "array");
+        assert_eq!(result["items"]["items"]["type"], "integer");
+        assert_eq!(result["minItems"], 1);
+        assert_eq!(result["maxItems"], 3);
+        assert_eq!(result["items"]["minItems"], 2);
+        assert_eq!(result["items"]["maxItems"], 4);
+    }
+
+    #[test]
+    fn object_types_to_json_schema() {
+        use std::collections::HashMap;
+        
+        let mut required = HashMap::new();
+        required.insert("id".to_string(), SchemaState::Number(NumberType::Integer { min: 1, max: 1000 }));
+        
+        let mut optional = HashMap::new();
+        optional.insert("name".to_string(), SchemaState::String(StringType::Unknown {
+            strings_seen: vec!["test".to_string()],
+            chars_seen: vec!['t', 'e', 's', 't'],
+            min_length: Some(1),
+            max_length: Some(50),
+        }));
+        
+        let object_schema = SchemaState::Object { required, optional };
+        let result = object_schema.to_json_schema();
+        
+        assert_eq!(result["type"], "object");
+        assert_eq!(result["additionalProperties"], false);
+        assert_eq!(result["required"], json!(["id"]));
+        assert_eq!(result["properties"]["id"]["type"], "integer");
+        assert_eq!(result["properties"]["name"]["type"], "string");
+    }
+
+    #[test]
+    fn object_empty_to_json_schema() {
+        use std::collections::HashMap;
+        let empty_object = SchemaState::Object {
+            required: HashMap::new(),
+            optional: HashMap::new(),
+        };
+        let result = empty_object.to_json_schema();
+        assert_eq!(result["type"], "object");
+        assert_eq!(result["additionalProperties"], false);
+        assert_eq!(result["required"], json!([]));
+        assert_eq!(result["properties"], json!({}));
+    }
+
+    #[test]
+    fn object_required_only_to_json_schema() {
+        use std::collections::HashMap;
+        let mut required = HashMap::new();
+        required.insert("id".to_string(), SchemaState::Number(NumberType::Integer { min: 1, max: 100 }));
+        required.insert("status".to_string(), SchemaState::Boolean);
+        
+        let required_only_object = SchemaState::Object {
+            required,
+            optional: HashMap::new(),
+        };
+        let result = required_only_object.to_json_schema();
+        assert_eq!(result["type"], "object");
+        assert_eq!(result["required"].as_array().unwrap().len(), 2);
+        assert!(result["required"].as_array().unwrap().contains(&json!("id")));
+        assert!(result["required"].as_array().unwrap().contains(&json!("status")));
+    }
+
+    #[test]
+    fn object_optional_only_to_json_schema() {
+        use std::collections::HashMap;
+        let mut optional = HashMap::new();
+        optional.insert("description".to_string(), SchemaState::String(StringType::Unknown {
+            strings_seen: vec!["test".to_string()],
+            chars_seen: vec!['t', 'e', 's', 't'],
+            min_length: None,
+            max_length: None,
+        }));
+        optional.insert("count".to_string(), SchemaState::Number(NumberType::Integer { min: 0, max: 10 }));
+        
+        let optional_only_object = SchemaState::Object {
+            required: HashMap::new(),
+            optional,
+        };
+        let result = optional_only_object.to_json_schema();
+        assert_eq!(result["type"], "object");
+        assert_eq!(result["required"], json!([]));
+        assert_eq!(result["properties"]["description"]["type"], "string");
+        assert_eq!(result["properties"]["count"]["type"], "integer");
+    }
+
+    #[test]
+    fn object_nested_to_json_schema() {
+        use std::collections::HashMap;
+        let mut inner_required = HashMap::new();
+        inner_required.insert("nested_id".to_string(), SchemaState::Number(NumberType::Integer { min: 1, max: 10 }));
+        
+        let mut outer_required = HashMap::new();
+        outer_required.insert("inner".to_string(), SchemaState::Object {
+            required: inner_required,
+            optional: HashMap::new(),
+        });
+        
+        let nested_object = SchemaState::Object {
+            required: outer_required,
+            optional: HashMap::new(),
+        };
+        let result = nested_object.to_json_schema();
+        assert_eq!(result["type"], "object");
+        assert_eq!(result["properties"]["inner"]["type"], "object");
+        assert_eq!(result["properties"]["inner"]["properties"]["nested_id"]["type"], "integer");
+        assert_eq!(result["properties"]["inner"]["required"], json!(["nested_id"]));
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -6,7 +6,6 @@ pub trait ToJsonSchema {
     fn to_json_schema_document(&self) -> serde_json::Value {
         let mut doc = serde_json::json!({
             "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "$id": "https://example.com/schema",
             "title": "Inferred Schema",
             "description": "Schema inferred by drivel from sample data"
         });
@@ -1001,7 +1000,6 @@ mod tests {
                     document["$schema"],
                     "https://json-schema.org/draft/2020-12/schema"
                 );
-                assert_eq!(document["$id"], "https://example.com/schema");
                 assert_eq!(document["title"], "Inferred Schema");
                 assert_eq!(
                     document["description"],


### PR DESCRIPTION
This PR adds a translation layer from the domain schema used internally by drivel to JSON schema (draft 2020-12).